### PR TITLE
add note about include=chain

### DIFF
--- a/custom-builds.html
+++ b/custom-builds.html
@@ -65,6 +65,7 @@ title: lodash custom builds
    <li>The <code>modularize</code> command uses the first `exports` values as its module format, ignoring subsequent values.</li>
    <li>Unless specified by <code>-o</code> or <code>--output</code> all files created are saved to the current working directory</li>
    <li>Node.js 0.10.8-0.10.11 <a href="https://github.com/joyent/node/issues/5622">have</a> <a href="https://github.com/joyent/node/issues/5688">bugs</a> preventing minified builds</li>
+   <li>If building with <code>include=chain</code>, you must also include <code>value</code>; e.g. <code>include=chain,value</code>.</li>
   </ul>
 
   <p>The following options are also supported:</p>


### PR DESCRIPTION
This was puzzling me, as building with `include=chain` was failing to produce a usable function.  I examined the code comments in `chain/lodash.js` and found something in there tucked away about `value` also being required.
